### PR TITLE
Add RunContinuationsAsynchronously to TaskDeliveryHandler

### DIFF
--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>0.9.5</VersionPrefix>
-    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net45;net46;netstandard1.3</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Confluent.Kafka</AssemblyName>

--- a/src/Confluent.Kafka/Impl/LibRdKafka.cs
+++ b/src/Confluent.Kafka/Impl/LibRdKafka.cs
@@ -21,7 +21,7 @@ using System.IO;
 using System.Text;
 using System.Runtime.InteropServices;
 using Confluent.Kafka.Internal;
-#if NET45
+#if NET45 || NET46
 using System.Reflection;
 using System.ComponentModel;
 #endif
@@ -34,7 +34,7 @@ namespace Confluent.Kafka.Impl
         //min librdkafka version, to change when binding to new function are added
         const long minVersion = 0x000903ff;
 
-#if NET45
+#if NET45 || NET46
         [Flags]
         public enum LoadLibraryFlags : uint
         {
@@ -84,7 +84,7 @@ namespace Confluent.Kafka.Impl
 
         static LibRdKafka()
         {
-#if NET45
+#if NET45 || NET46
             try
             {
                 // In net45, we don't put the native dlls in the assembly directory

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -182,11 +182,19 @@ namespace Confluent.Kafka
 
         private sealed class TaskDeliveryHandler : TaskCompletionSource<Message>, IDeliveryHandler
         {
+#if !NET45
+            public TaskDeliveryHandler() : base(TaskContinuationOptions.RunContinuationsAsynchronously)
+            { }
+#endif
             public bool MarshalData { get { return true; } }
 
             public void HandleDeliveryReport(Message message)
             {
+#if NET45
                 System.Threading.Tasks.Task.Run(() => SetResult(message));
+#else
+                SetResult(message);
+#endif
             }
         }
 
@@ -806,6 +814,9 @@ namespace Confluent.Kafka
         private class TypedTaskDeliveryHandlerShim : TaskCompletionSource<Message<TKey, TValue>>, IDeliveryHandler
         {
             public TypedTaskDeliveryHandlerShim(TKey key, TValue val)
+#if !NET45
+                : base(TaskContinuationOptions.RunContinuationsAsynchronously)
+#endif
             {
                 Key = key;
                 Value = val;
@@ -829,7 +840,11 @@ namespace Confluent.Kafka
                     message.Error
                 );
 
+#if NET45
                 System.Threading.Tasks.Task.Run(() => SetResult(mi));
+#else
+                SetResult(mi);
+#endif
             }
         }
 


### PR DESCRIPTION
Add net46 as target framework to have this on as many target as possible
RunContinuationsAsynchronously will reduce the overhead (almost null) in regard of Task.Run

results of benchmark on windows here: https://github.com/confluentinc/confluent-kafka-dotnet/pull/180