### PR TITLE
do not discard offset from dateTimeOffset

### DIFF
--- a/src/Confluent.Kafka/Timestamp.cs
+++ b/src/Confluent.Kafka/Timestamp.cs
@@ -101,7 +101,7 @@ namespace Confluent.Kafka
         ///     The DateTimeOffset value corresponding to the timestamp.
         /// </param>
         public Timestamp(DateTimeOffset dateTimeOffset)
-            : this(dateTimeOffset.DateTime, TimestampType.CreateTime) 
+            : this(dateTimeOffset.UtcDateTime, TimestampType.CreateTime) 
         {}
 
         /// <summary>


### PR DESCRIPTION
Timestamp class should represent a single point in time.
When created using dateTimeOffset the offset part is discarded and the time is assumed to be local time.
I think this is wrong and we should send utcTime to server.