### PR TITLE
ReadOnlySpan<byte>.Empty, not new byte[]

### DIFF
--- a/src/Confluent.Kafka/ConsumerBase.cs
+++ b/src/Confluent.Kafka/ConsumerBase.cs
@@ -49,8 +49,6 @@ namespace Confluent.Kafka
 
         private readonly SafeKafkaHandle kafkaHandle;
 
-        private static readonly byte[] EmptyBytes = new byte[0];
-
 
         private readonly Librdkafka.ErrorDelegate errorCallbackDelegate;
         private void ErrorCallback(IntPtr rk, ErrorCode err, string reason, IntPtr opaque)
@@ -392,8 +390,13 @@ namespace Confluent.Kafka
                     unsafe
                     {
                         key = keyDeserializer.Deserialize(
-                            msg.key == IntPtr.Zero ? EmptyBytes : new ReadOnlySpan<byte>(msg.key.ToPointer(), (int)msg.key_len),
-                            msg.key == IntPtr.Zero, true, new MessageMetadata { Timestamp = timestamp, Headers = headers }, new TopicPartition(topic, msg.partition));
+                            msg.key == IntPtr.Zero
+                                ? ReadOnlySpan<byte>.Empty
+                                : new ReadOnlySpan<byte>(msg.key.ToPointer(), (int)msg.key_len),
+                            msg.key == IntPtr.Zero,
+                            true,
+                            new MessageMetadata { Timestamp = timestamp, Headers = headers },
+                            new TopicPartition(topic, msg.partition));
                     }
                 }
                 catch (Exception ex)
@@ -421,8 +424,13 @@ namespace Confluent.Kafka
                     unsafe
                     {
                         val = valueDeserializer.Deserialize(
-                            msg.val == IntPtr.Zero ? EmptyBytes : new ReadOnlySpan<byte>(msg.val.ToPointer(), (int)msg.len),
-                            msg.val == IntPtr.Zero, false, new MessageMetadata { Timestamp = timestamp, Headers = headers }, new TopicPartition(topic, msg.partition));
+                            msg.val == IntPtr.Zero
+                                ? ReadOnlySpan<byte>.Empty
+                                : new ReadOnlySpan<byte>(msg.val.ToPointer(), (int)msg.len),
+                            msg.val == IntPtr.Zero,
+                            false,
+                            new MessageMetadata { Timestamp = timestamp, Headers = headers },
+                            new TopicPartition(topic, msg.partition));
                     }
                 }
                 catch (Exception ex)


### PR DESCRIPTION
this is a minor internal improvement suggested by @AndyPook after https://github.com/mhowlett/confluent-kafka-dotnet/pull/6 was approved. 

(unit and integration tests all pass)