### PR TITLE
enum ignore case

### DIFF
--- a/src/Confluent.Kafka/Config.cs
+++ b/src/Confluent.Kafka/Config.cs
@@ -131,7 +131,7 @@ namespace Confluent.Kafka
         {
             var result = Get(key);
             if (result == null) { return null; }
-            return Enum.Parse(type, result);
+            return Enum.Parse(type, result, ignoreCase: true);
         }
 
         /// <summary>
@@ -147,7 +147,7 @@ namespace Confluent.Kafka
 
             if (val is Enum)
             {
-                this.properties[name] = val.ToString().ToLower();
+                this.properties[name] = val.ToString().ToLowerInvariant();
             }
             else
             {

--- a/test/Confluent.Kafka.UnitTests/ConfigEnums.cs
+++ b/test/Confluent.Kafka.UnitTests/ConfigEnums.cs
@@ -1,0 +1,33 @@
+﻿using Xunit;
+
+namespace Confluent.Kafka.UnitTests
+{
+    public class ConfigEnumTests
+    {
+        [Fact]
+        public void ConsumerEnumProperties()
+        {
+            var config = new ConsumerConfig
+            {
+                AutoOffsetReset = AutoOffsetResetType.Earliest
+            };
+
+            var value = config.AutoOffsetReset;
+
+            Assert.Equal(AutoOffsetResetType.Earliest, value);
+        }
+
+        [Fact]
+        public void ProducerEnumProperties()
+        {
+            var config = new ProducerConfig
+            {
+                QueuingStrategy = QueuingStrategyType.Fifo,
+                Partitioner = PartitionerType.Consistent
+            };
+
+            Assert.Equal(QueuingStrategyType.Fifo, config.QueuingStrategy);
+            Assert.Equal(PartitionerType.Consistent, config.Partitioner);
+        }
+    }
+}


### PR DESCRIPTION
issue #631

setting the property uses `.ToLower()` but when getting  `Enum.Parse` expects the case to be exactly the same as the enum member.

Changed to use `.ToLowerInvariant()` to prevent issues with local culture.
Use case-insensitive `Enum.Parse`