### PR TITLE
how to improve consumer throughput by 4x-5x...

### DIFF
--- a/test/Confluent.Kafka.Benchmark/Confluent.Kafka.Benchmark.csproj
+++ b/test/Confluent.Kafka.Benchmark/Confluent.Kafka.Benchmark.csproj
@@ -3,12 +3,16 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>Confluent.Kafka.Benchmark</AssemblyName>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/test/Confluent.Kafka.Benchmark/Program.cs
+++ b/test/Confluent.Kafka.Benchmark/Program.cs
@@ -15,35 +15,56 @@
 // Refer to LICENSE for more information.
 
 using System;
+using Mono.Options;
 
 
 namespace Confluent.Kafka.Benchmark
 {
     public class Program
     {
+        private static void WriteHelp(OptionSet options)
+        {
+            Console.WriteLine("Options: ");
+            options.WriteOptionDescriptions(Console.Out);
+        }
+
         public static void Main(string[] args)
         {
-            if (args.Length != 2 && args.Length != 3)
+            string bootstrapServers = null;
+            string topic = null;
+            int headerCount = 0;
+            int messageCount = 10_000_000;
+
+            var p = new OptionSet
             {
-                Console.WriteLine($"Usage: .. <broker,broker..> <topic> [header-count]");
-                return;
+                { "b=", "Comma separated list of brokers (required)", v => bootstrapServers = v },
+                { "t=", "Kafka topic (required)", v => topic = v },
+                { "h=", "Header count (default 0)", v => headerCount = int.Parse(v) },
+                { "n=", "Number of messages to produce/consume (default 1M)", v => messageCount = int.Parse(v) }
+            };
+
+            if (args.Length == 0)
+            {
+                WriteHelp(p);
+                Environment.Exit(0);
             }
 
-            var bootstrapServers = args[0];
-            var topic = args[1];
-            var headerCount = 0;
-            if (args.Length > 2)
+            try
             {
-                headerCount = int.Parse(args[2]);
+                p.Parse(args);
+            }
+            catch (Exception)
+            {
+                WriteHelp(p);
+                Environment.Exit(1);
             }
 
-            const int NUMBER_OF_MESSAGES = 5000000;
-            const int NUMBER_OF_TESTS = 1;
+            if (bootstrapServers == null) { Console.WriteLine("broker must be specified."); Environment.Exit(1); }
+            if (topic == null) { Console.WriteLine("topic must be specified"); Environment.Exit(1); }
 
-            BenchmarkProducer.TaskProduce(bootstrapServers, topic, NUMBER_OF_MESSAGES, headerCount, NUMBER_OF_TESTS);
-            var firstMessageOffset = BenchmarkProducer.DeliveryHandlerProduce(bootstrapServers, topic, NUMBER_OF_MESSAGES, headerCount, NUMBER_OF_TESTS);
-
-            BenchmarkConsumer.Consume(bootstrapServers, topic, firstMessageOffset, NUMBER_OF_MESSAGES, headerCount, NUMBER_OF_TESTS);
+            BenchmarkProducer.TaskProduce(bootstrapServers, topic, messageCount, headerCount);
+            var firstMessageOffset = BenchmarkProducer.DeliveryHandlerProduce(bootstrapServers, topic, messageCount, headerCount);
+            BenchmarkConsumer.Consume(bootstrapServers, topic, firstMessageOffset, messageCount, headerCount);
         }
     }
 }


### PR DESCRIPTION
... and other good stuff.

@edenhill @rnpridgeon

- increasing `QueuedMinMessages` results in an enormous improvement in maximum consume throughput (from ~240K -> 1.1M 100 byte msg/s). 
- produce (delivery handler variant) and consume benchmark tests now report steady-state throughput statistics as the test progresses. this is not easy to implement in the task based produce variant, and would impact performance.
- i haven't included the serializer variants of the tests as per the `bmark` branch - just improved on the raw tests. I may do this later, but it's lower priority.
- using `MonoOptions` to parse command line options, which is nicer and allows for future improvements to the tests.
- using `Stopwatch` instead of `DateTime.Now`, which is higher precision.
- I prioritized this change since prior to the 1.0 release, I want to measure the performance impact of using `MemoryPool` in the serializer API, and this provides a foundation.

Representative output:
```
rdkafka#producer-1 producing on tt1 [Task]:
  Total:
    Produced 10000000 messages in 35107ms
    284k msg/s
rdkafka#producer-2 producing on tt1 [Action<Message>]:
  Produced 1000000 messages in 2080ms
  480k msg/s
  Produced 1000000 messages in 2139ms
  467k msg/s
  Produced 1000000 messages in 2259ms
  442k msg/s
  Produced 1000000 messages in 2160ms
  462k msg/s
  Produced 1000000 messages in 2184ms
  457k msg/s
  Produced 1000000 messages in 2118ms
  472k msg/s
  Produced 1000000 messages in 2036ms
  491k msg/s
  Produced 1000000 messages in 2017ms
  495k msg/s
  Produced 1000000 messages in 2035ms
  491k msg/s
  Produced 1000000 messages in 2028ms
  493k msg/s
  Total:
    Produced 10000000 messages in 21056ms
    474k msg/s
rdkafka#consumer-3 consuming from tt1:
  Consumed 1000000 messages in 913ms
  1095k msg/s
  Consumed 1000000 messages in 872ms
  1146k msg/s
  Consumed 1000000 messages in 888ms
  1126k msg/s
  Consumed 1000000 messages in 911ms
  1097k msg/s
  Consumed 1000000 messages in 891ms
  1122k msg/s
  Consumed 1000000 messages in 904ms
  1106k msg/s
  Consumed 1000000 messages in 820ms
  1219k msg/s
  Consumed 1000000 messages in 779ms
  1283k msg/s
  Consumed 1000000 messages in 848ms
  1179k msg/s
  Total:
    Consumed 9999999 messages in 8678ms
    1152k msg/s
```